### PR TITLE
Updates to use ECEI HDF5 to define cfg "diagnostic/parameters" dict, send in adios stream

### DIFF
--- a/delta/generator.py
+++ b/delta/generator.py
@@ -63,6 +63,7 @@ logger.info(f"Streaming channel name = {gen_channel_name(cfg['diagnostic'])}")
 writer.DefineVariable(gen_var_name(cfg)[rank],
                       dataloader.get_chunk_shape(),
                       dataloader.dtype)
+writer.DefineAttributes("cfg",cfg)
 writer.Open()
 
 logger.info("Start sending on channel:")

--- a/delta/sources/dataloader.py
+++ b/delta/sources/dataloader.py
@@ -63,7 +63,7 @@ class _loader_ecei():
         
         #update config file with the ECEI HDF5 file attributes
         #(these changes will be reflected in cfg_all in generator.py)
-        self._read_atrributes_from_hdf5(cfg_all)
+        self._read_attributes_from_hdf5(cfg_all)
 
         # Generate start/stop time for timebase
         self.f_sample = cfg_all["diagnostic"]["parameters"]["SampleRate"] * 1e3


### PR DESCRIPTION
This updates the flexible workflow to read in the "diagnostic/parameters" section of the config file from the ECEI HDF5 file instead, and stream the entire cfg dictionary as an adios stream attribute, in json string format. 
1. It defines a new method `_read_attributes_from_hdf5` in `delta/sources/dataloader.py _loader_ecei` class, which reads in the needed attributes (are there more?) to replace the defaults in the config file (or we can simply take them out of the config file, since it will update the dictionary with or without those keys present). The dictionary updates should be present in cfg_all in generator.py, since dictionaries are mutable objects. 
2. In delta/generator.py, it then uses the writer_gen `DefineAttributes` to define this as at the "cfg" attribute in the adios stream (writer_gen takes care of the json serialization). 
3. In delta/processor.py, it follows the receiver_brute.py setup, where in the beginning of the main adios stream while loop, it reads in the attribute "cfg", then defines a number of objects which previously were defined before the while loop (**NOTE: check that these are valid to be moved!!!!!!!! It looks OK to me**)
