### PR TITLE
Try tmp shifter

### DIFF
--- a/delta/storage/backend_numpy.py
+++ b/delta/storage/backend_numpy.py
@@ -87,7 +87,7 @@ class backend_numpy():
         # Adds the channel_serialization key to cfg
         #cfg.update(j)
 
-        with open(join(self.basedir, "config.json"), "w") as df:
+        with open("/tmp/config.json"), "w") as df:
             json.dump(cfg, df)
 
         return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ azure-storage-blob==2.1.0
 black>=20.8b1
 numba
 cupy-cuda110
+azure-storage
+

--- a/tests/test_kernels_cu.py
+++ b/tests/test_kernels_cu.py
@@ -41,7 +41,8 @@ def test_kernels(config_analysis_cu):
 
     # Download the blob(s).
     # Add '_DOWNLOADED' as prefix to '.txt' so you can see both files in Documents.
-    full_path_to_file = os.path.join(os.getcwd(), 
+    # shifter is read-only so let's use /tmp, the only place we're allowed to read/write
+    full_path_to_file = os.path.join('/tmp',
                                      str.replace(local_file_name, '.npz', '_DOWNLOADED.npz'))
     blob_service_client.get_blob_to_path(container_name, local_file_name, full_path_to_file)
 

--- a/tests/test_kernels_cy.py
+++ b/tests/test_kernels_cy.py
@@ -39,7 +39,8 @@ def test_kernels(config_analysis_cy):
 
     # Download the blob(s).
     # Add '_DOWNLOADED' as prefix to '.txt' so you can see both files in Documents.
-    full_path_to_file = os.path.join(os.getcwd(), 
+    # shifter is read-only so let's use /tmp, the only place we're allowed to read/write
+    full_path_to_file = os.path.join('/tmp',
                                      str.replace(local_file_name, '.npz', '_DOWNLOADED.npz'))
     blob_service_client.get_blob_to_path(container_name, local_file_name, full_path_to_file)
 

--- a/tests/test_kernels_py.py
+++ b/tests/test_kernels_py.py
@@ -39,7 +39,8 @@ def test_kernels(config_all):
 
     # Download the blob(s).
     # Add '_DOWNLOADED' as prefix to '.txt' so you can see both files in Documents.
-    full_path_to_file = os.path.join(os.getcwd(), 
+    # shifter is read-only so let's use /tmp, the only place we're allowed to read/write
+    full_path_to_file = os.path.join('/tmp',
                                      str.replace(local_file_name, '.npz', '_DOWNLOADED.npz'))
     blob_service_client.get_blob_to_path(container_name, local_file_name, full_path_to_file)
 

--- a/tests/test_pre_bandpass.py
+++ b/tests/test_pre_bandpass.py
@@ -27,7 +27,9 @@ def test_pre_bandpass_iir(config_all):
 
     # Download the blob(s).
     # Add '_DOWNLOADED' as prefix to '.txt' so you can see both files in Documents.
-    full_path_to_file = os.path.join(os.getcwd(), str.replace(local_file_name, '.npz', '_DOWNLOADED.npz'))
+    # shifter is read-only so let's use /tmp, the only place we're allowed to read/write
+    full_path_to_file = os.path.join('/tmp',
+                                     str.replace(local_file_name, '.npz', '_DOWNLOADED.npz'))
     blob_service_client.get_blob_to_path(container_name, local_file_name, full_path_to_file)
 
     with np.load(full_path_to_file) as df:


### PR DESCRIPTION
Changes location of  temporary files that are written during unit tests to `/tmp` 

This will enable tests to run inside a read-only Shifter container

Tests are passing using this fork inside the Docker container