### PR TITLE
add cupy to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ azure-storage-blob==2.1.0
 black>=20.8b1
 numba
 azure-storage
+cupy-cuda110


### PR DESCRIPTION
A quick PR to add CuPy to requirements file

The version of CuPy must match the CUDA version. The current CUDA version in the container is 11.0 so when this is upgraded, we'll have to be careful to upgrade the CuPy verison to match. 