### PR TITLE
add matplotlib to requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ black>=20.8b1
 numba
 cupy-cuda115
 ipykernel
+matplotlib


### PR DESCRIPTION
Mohammed noted that matplotlib is missing from our requirements file. Added. 