### PR TITLE
pin build to zeromq 4.3.2 and adios 2.7.1

### DIFF
--- a/container/ContainerREADME.md
+++ b/container/ContainerREADME.md
@@ -14,7 +14,7 @@ file, you'll need to do the build from the directory where it is located.
 Here we are building on a NERSC staff podman node:
 
 ```
-podman build -t registry.nersc.gov/das/delta:5.0 . -f container/delta-outside/Dockerfile
+podman build -t registry.nersc.gov/das/delta:6.0 . -f container/delta-outside/Dockerfile
 ```
 
 We're using `registry.nersc.gov` to store our image. You may first need to log in
@@ -29,14 +29,14 @@ Note your NERSC username and password (no OTP) should be used.
 To push:
 
 ```
-podman push registry.nersc.gov/das/delta:5.0
+podman push registry.nersc.gov/das/delta:6.0
 ```
 
 To pull onto Cori/Perlmutter:
 
 ```
 shifterimg login registry.nersc.gov
-shifterimg pull registry.nersc.gov/das/delta5.0
+shifterimg pull registry.nersc.gov/das/delta:6.0
 ```
 
 ## Using at NERSC
@@ -45,7 +45,7 @@ There are two main ways we can run Delta in Shifter-- the first is with Delta
 installed outside the container, and the second is with Delta install inside
 the container.
 
-The image we use is called `registry.nersc.gov/das/delta:5.0`.
+The image we use is called `registry.nersc.gov/das/delta:6.0`.
 
 This image was built using the `delta-outside` Dockerfile and will use the
 installation of Delta outside the container.
@@ -59,7 +59,7 @@ it must be done inside Shifter.
 
 ```
 cd $SCRATCH/delta/delta/analysis
-shifter --image=registry.nersc.gov/das/delta:5.0 python3 setup.py build_ext --inplace
+shifter --image=registry.nersc.gov/das/delta:6.0 python3 setup.py build_ext --inplace
 ```
 
 Now we are ready to run Delta.
@@ -67,7 +67,7 @@ Now we are ready to run Delta.
 ### Haswell
 
 ```
-salloc -N 4 -C haswell -q interactive --image=registry.nersc.gov/das/delta:5.0
+salloc -N 4 -C haswell -q interactive --image=registry.nersc.gov/das/delta:6.0
 ```
 
 cd to wherever you have installed delta. For me it's
@@ -88,7 +88,7 @@ On corigpu, request the image during your interactive job:
 
 ```
 module load cgpu
-salloc -N 1 -C gpu -G 1 -t 60 -c 16 --image=registry.nersc.gov/das/delta:5.0
+salloc -N 1 -C gpu -G 1 -t 60 -c 16 --image=registry.nersc.gov/das/delta:6.0
 ```
 
 ```
@@ -115,3 +115,6 @@ don't understand. To run pytest you'll have to run in the container:
 shifter --volume="/global/cscratch1/sd/stephey/delta/delta:/opt/delta" /bin/bash
 pytest /opt/delta/tests
 ```
+
+It's really important to match the versions of ADIOS2/zeromq on the KSTAR dtn. Here we are using
+ADIOS2 2.7.1 and zeromq 4.3.2 (the version on the KSTAR dtn). 

--- a/container/delta-outside/Dockerfile
+++ b/container/delta-outside/Dockerfile
@@ -14,7 +14,6 @@ RUN \
         gfortran             \
         python3-dev          \
         python3-pip          \
-        libzmq3-dev          \
         wget              && \
     apt-get clean all
 
@@ -56,6 +55,14 @@ RUN python3 -m pip install -U setuptools pip
 ADD requirements.txt /opt/requirements.txt
 RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
+#KSTAR DTN has 4.3.2, it's very important to match!
+ARG zmq_version=4.3.2
+RUN wget https://github.com/zeromq/libzmq/releases/download/v$zmq_version/zeromq-$zmq_version.tar.gz && \
+    tar vxf zeromq-$zmq_version.tar.gz && \
+    cd zeromq-$zmq_version && \
+    ./configure --prefix=/opt/zeromq &&  make -j 32 && make install
+ENV CMAKE_PREFIX_PATH=/opt/zeromq:$CMAKE_PREFIX_PATH
+
 #for the moment i think we're ok without the requirements since
 #we install mpi4py ourselves and delta installs numpy
 #install adios from 2.7.1 release
@@ -82,6 +89,7 @@ RUN cd /opt/adios2-build                                  && \
         -DADIOS2_USE_Profiling=OFF                           \
         -DADIOS2_USE_DATAMAN=ON                              \
         -DADIOS2_USE_ZeroMQ=ON                               \
+        -DZeroMQ_INCLUDE_DIR=/opt/zeromq/include             \
         ../adios2-devel                                   && \
         make -j 32                                        && \
         make install      

--- a/container/delta-outside/Dockerfile
+++ b/container/delta-outside/Dockerfile
@@ -12,6 +12,7 @@ RUN \
         cmake                \
         gcc                  \
         gfortran             \
+        git                  \
         python3-dev          \
         python3-pip          \
         wget              && \
@@ -66,11 +67,13 @@ ENV CMAKE_PREFIX_PATH=/opt/zeromq:$CMAKE_PREFIX_PATH
 #for the moment i think we're ok without the requirements since
 #we install mpi4py ourselves and delta installs numpy
 #install adios from 2.7.1 release
-RUN wget https://github.com/ornladios/ADIOS2/archive/94c2e377eba2947ae9739c1dd42f616a1296f12a.tar.gz && \    
-    tar xvf 94c2e377eba2947ae9739c1dd42f616a1296f12a.tar.gz                                          && \
-    mv ADIOS2-94c2e377eba2947ae9739c1dd42f616a1296f12a adios2-devel                                  && \
-    mkdir adios2-build                                                                               && \
-    rm -rf master.tar.gz
+RUN git clone https://github.com/ornladios/ADIOS2.git adios2-devel && \    
+    cd adios2-devel && \
+    git checkout v2.7.1-279-gd65478233 && \
+    cd .. && \
+    mkdir adios2-build             
+
+RUN mkdir -p /opt/adios2-container
 
 ENV PREFIX /opt/adios2-container
 

--- a/setup/build-delta-dtn.sh
+++ b/setup/build-delta-dtn.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 #here we'll attempt to build a version of delta on the dtns
 #that is compatible with the version in our current delta/4:0 container
 #current version of build is https://github.com/rkube/delta/blob/master/container/delta-outside/Dockerfile
@@ -11,10 +13,8 @@
 #existing builds, so be careful
 
 #location of your delta clone
-###
 ### change me!!!
 export delta_install=/global/cscratch1/sd/stephey/delta
-###
 ###
 
 export build=$delta_install/build
@@ -55,10 +55,12 @@ export PATH=$build/cmake/bin:$PATH
 
 ###############zeromq##############
 
+#KSTAR DTN has 4.3.2, it's very important to match!
 cd $build
-wget https://github.com/zeromq/libzmq/releases/download/v4.3.4/zeromq-4.3.4.tar.gz
-tar vxf zeromq-4.3.4.tar.gz
-cd zeromq-4.3.4
+zmq_version=4.3.2
+wget https://github.com/zeromq/libzmq/releases/download/v$zmq_version/zeromq-$zmq_version.tar.gz
+tar vxf zeromq-$zmq_version.tar.gz
+cd zeromq-$zmq_version
 ./configure --prefix=$build/zeromq &&  make -j 8 && make install
 
 export LD_LIBRARY_PATH=$build/zeromq/lib:$LD_LIBRARY_PATH

--- a/setup/build-delta-dtn.sh
+++ b/setup/build-delta-dtn.sh
@@ -13,8 +13,10 @@ set -x
 #existing builds, so be careful
 
 #location of your delta clone
+###
 ### change me!!!
 export delta_install=/global/cscratch1/sd/stephey/delta
+###
 ###
 
 export build=$delta_install/build
@@ -30,7 +32,7 @@ wget https://www.mpich.org/static/downloads/$mpich/$mpich_prefix.tar.gz
 tar xvzf $mpich_prefix.tar.gz
 cd $mpich_prefix
 ./configure  --prefix=$build/mpich
-make -j 8
+make -j 32
 make install
 
 export LD_LIBRARY_PATH=$build/mpich/lib:$LD_LIBRARY_PATH
@@ -47,7 +49,7 @@ cd $build
 wget https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2.tar.gz
 tar xvzf cmake-3.23.2.tar.gz
 cd cmake-3.23.2
-./bootstrap --prefix=$build/cmake && make -j 8 && make install
+./bootstrap --prefix=$build/cmake && make -j 32 && make install
 
 export PATH=$build/cmake/bin:$PATH
 
@@ -61,7 +63,7 @@ zmq_version=4.3.2
 wget https://github.com/zeromq/libzmq/releases/download/v$zmq_version/zeromq-$zmq_version.tar.gz
 tar vxf zeromq-$zmq_version.tar.gz
 cd zeromq-$zmq_version
-./configure --prefix=$build/zeromq &&  make -j 8 && make install
+./configure --prefix=$build/zeromq &&  make -j 32 && make install
 
 export LD_LIBRARY_PATH=$build/zeromq/lib:$LD_LIBRARY_PATH
 
@@ -75,19 +77,22 @@ source activate delta-dtn
 python -m pip install --no-cache-dir -r $delta_install/requirements.txt
 #we can get away with this here since we're bringing our own mpich stack
 #and actually we don't want to link to cray mpich anyway
-python -m pip install mpi4py
+conda uninstall mpi4py -y
+MPICC=mpicc MPICXX=mpicxx pip install -U -I --global-option=build_ext mpi4py
+#python -m pip install mpi4py
 export conda_env=$CONDA_PREFIX
-conda deactivate
-module unload python
+#conda deactivate
+#module unload python
 
 #--------------------------------
 
 #############adios2##############
 
 cd $build
-wget https://github.com/ornladios/ADIOS2/archive/94c2e377eba2947ae9739c1dd42f616a1296f12a.tar.gz
-tar xvf 94c2e377eba2947ae9739c1dd42f616a1296f12a.tar.gz
-mv ADIOS2-94c2e377eba2947ae9739c1dd42f616a1296f12a adios2-devel
+git clone https://github.com/ornladios/ADIOS2.git adios2-devel
+cd adios2-devel
+git checkout v2.7.1-279-gd65478233
+cd ..
 rm -rf adios2-build
 mkdir adios2-build
 cd adios2-build
@@ -110,6 +115,6 @@ cmake                                                        \
         -DADIOS2_USE_DATAMAN=ON                              \
         -DADIOS2_USE_ZeroMQ=ON                               \
         ../adios2-devel
-make -j 8 && make install
+make -j 32 && make install
 
 #--------------------------------

--- a/setup/setup-delta-dtn.sh
+++ b/setup/setup-delta-dtn.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 
 #location of your delta clone
-###
 ### change me!!!
 export delta_install=/global/cscratch1/sd/stephey/delta
-###
-###
 export build=$delta_install/build
+###
 
 #source custom python env
 module load python
@@ -14,6 +12,9 @@ source activate delta-dtn
 
 #point to adios2 python lib
 export PYTHONPATH=$build/adios2/lib/python3.8/site-packages/adios2:$PYTHONPATH
+
+##add adios to path
+#export PATH=$build/adios2/bin:$PATH
 
 #for debugging:
 #export LD_LIBRARY_PATH=$build/mpich/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
Based on our tests this morning, @jychoi-hpc found that the version of zeromq used by DELTA on the KSTAR DTNs is 4.3.2, and this must match what we are using at NERSC

This MR:
- Adjusts our DTN build script and Dockerfile to build the DELTA stack/ADIOS2 using zeromq 4.3.2
- The Docker cmake had some trouble finding zeromq, so add some config hints
- Adjusts the container README accordingly. 